### PR TITLE
Update mixin compatibility level to JAVA_25 to resolve a warning

### DIFF
--- a/src/main/resources/birdaddon.mixins.json
+++ b/src/main/resources/birdaddon.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.barefootbird.birdaddon.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "verbose": true,
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This resolves the following warning in latest.log when launching with BirdAddon:

[21:18:40] [Render thread/WARN]: birdaddon.mixins.json:MixinAbstractSoundInstance from mod birdaddon: Class version 69 required is higher than the class version supported by the current version of Mixin (JAVA_21 supports class version 65)

Newest Fabric Loader recognizes the JAVA_25 entry in mixins.json, but since birdaddon was using compatibilityLevel JAVA_21 while it's compiled mixin .class files had bytecode version 69 (Java 25), it was causing this warning.